### PR TITLE
feat: add gogcli to hermes-test container

### DIFF
--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -201,6 +201,19 @@ RUN set -eux; \
     dpkg -i /tmp/bottom.deb; \
     rm -f /tmp/bottom.deb
 
+# renovate: datasource=github-releases depName=steipete/gogcli
+ARG GOGCLI_VERSION=0.13.0
+RUN set -eux; \
+    source /etc/tool-arch.env; \
+    asset="gogcli_${GOGCLI_VERSION}_linux_${DEB_ARCH}.tar.gz"; \
+    base="https://github.com/steipete/gogcli/releases/download/v${GOGCLI_VERSION}"; \
+    curl -fsSL "${base}/${asset}" -o /tmp/gogcli.tar.gz; \
+    curl -fsSL "${base}/checksums.txt" -o /tmp/gogcli_checksums.txt; \
+    cd /tmp; \
+    grep " ${asset}$" gogcli_checksums.txt | sha256sum -c -; \
+    tar -xzf gogcli.tar.gz -C /usr/local/bin gogcli; \
+    rm -f /tmp/gogcli.tar.gz /tmp/gogcli_checksums.txt
+
 RUN set -eux; \
     printf '%s\n' \
       "alias ls='eza --icons=auto'" \
@@ -236,7 +249,8 @@ RUN set -eux; \
     zoxide --version; \
     hyperfine --version; \
     btm --version; \
-    gh --version
+    gh --version; \
+    gogcli --version
 
 # renovate: datasource=npm depName=opencode-ai
 ARG OPENCODE_VERSION=1.14.18


### PR DESCRIPTION
## Summary

Adds gogcli (Google Suite CLI) to the hermes-test container.

## Changes

- Install gogcli v0.13.0 with SHA256 checksum verification
- Architecture-aware download using existing `DEB_ARCH` pattern (amd64/arm64)
- Follows same installation pattern as gh CLI (checksum-verified)
- Added to verification block to confirm installation

## Details

**Tool:** [steipete/gogcli](https://github.com/steipete/gogcli) - Google Suite CLI for Gmail, GCal, GDrive, GContacts

**Install method:** Download tar.gz from GitHub releases, verify checksum, extract binary to `/usr/local/bin/gogcli`

**Version management:** Renovate will auto-update via `# renovate: datasource=github-releases depName=steipete/gogcli` comment

## Testing

CI will build and push the container image. The verification block runs `gogcli --version` to confirm successful installation.