### PR TITLE
fix: correct gogcli binary extraction

### DIFF
--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -211,8 +211,10 @@ RUN set -eux; \
     curl -fsSL "${base}/checksums.txt" -o /tmp/gogcli_checksums.txt; \
     cd /tmp; \
     grep " ${asset}$" gogcli_checksums.txt | sha256sum -c -; \
-    tar -xzf gogcli.tar.gz -C /usr/local/bin gogcli; \
-    rm -f /tmp/gogcli.tar.gz /tmp/gogcli_checksums.txt
+    mkdir -p /tmp/gogcli-extract; \
+    tar -xzf gogcli.tar.gz -C /tmp/gogcli-extract; \
+    install -m 0755 /tmp/gogcli-extract/gog /usr/local/bin/gogcli; \
+    rm -rf /tmp/gogcli.tar.gz /tmp/gogcli_checksums.txt /tmp/gogcli-extract
 
 RUN set -eux; \
     printf '%s\n' \


### PR DESCRIPTION
## Problem

The previous PR #118 failed to build because the tarball contains a binary named `gog`, not `gogcli`.

```
tar -tzf gogcli_0.13.0_linux_amd64.tar.gz
CHANGELOG.md
LICENSE
README.md
gog  # <-- binary is named 'gog', not 'gogcli'
```

## Fix

- Extract tarball to temp directory
- Install `gog` binary as `gogcli` (renaming during install)
- Clean up temp files

This matches the pattern used for other tools in the Dockerfile (bat, dust, sd, zoxide) that also extract to temp dirs before installing.