### PR TITLE
feat(hermes-test): add npm AI coding tools with Renovate versioning

### DIFF
--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -246,20 +246,18 @@ RUN set -eux; \
 
 # renovate: datasource=npm depName=@qwen-code/qwen-code
 ARG QWEN_CODE_VERSION=0.15.3
-RUN set -eux; \
-    npm install -g @qwen-code/qwen-code@${QWEN_CODE_VERSION}; \
-    qwen-code --version
-
 # renovate: datasource=npm depName=@sourcegraph/amp
 ARG AMP_VERSION=0.0.1777248626-ga45149
-RUN set -eux; \
-    npm install -g @sourcegraph/amp@${AMP_VERSION}; \
-    amp --version
-
 # renovate: datasource=npm depName=cline
 ARG CLINE_VERSION=2.17.0
 RUN set -eux; \
-    npm install -g cline@${CLINE_VERSION}; \
-    cline --version
+    npm install -g \
+        @qwen-code/qwen-code@${QWEN_CODE_VERSION} \
+        @sourcegraph/amp@${AMP_VERSION} \
+        cline@${CLINE_VERSION}; \
+    qwen-code --version; \
+    amp --version; \
+    cline --version; \
+    npm cache clean --force
 
 USER hermes

--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -250,14 +250,22 @@ ARG QWEN_CODE_VERSION=0.15.3
 ARG AMP_VERSION=0.0.1777248626-ga45149
 # renovate: datasource=npm depName=cline
 ARG CLINE_VERSION=2.17.0
+# renovate: datasource=npm depName=@kilocode/cli
+ARG KILO_VERSION=7.2.14
+# renovate: datasource=npm depName=@google/gemini-cli
+ARG GEMINI_CLI_VERSION=0.39.1
 RUN set -eux; \
     npm install -g \
         @qwen-code/qwen-code@${QWEN_CODE_VERSION} \
         @sourcegraph/amp@${AMP_VERSION} \
-        cline@${CLINE_VERSION}; \
+        cline@${CLINE_VERSION} \
+        @kilocode/cli@${KILO_VERSION} \
+        @google/gemini-cli@${GEMINI_CLI_VERSION}; \
     qwen-code --version; \
     amp --version; \
     cline --version; \
+    kilo --version; \
+    gemini --version; \
     npm cache clean --force
 
 USER hermes

--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -244,4 +244,22 @@ RUN set -eux; \
     npm install -g opencode-ai@${OPENCODE_VERSION}; \
     opencode --version
 
+# renovate: datasource=npm depName=@qwen-code/qwen-code
+ARG QWEN_CODE_VERSION=0.15.3
+RUN set -eux; \
+    npm install -g @qwen-code/qwen-code@${QWEN_CODE_VERSION}; \
+    qwen-code --version
+
+# renovate: datasource=npm depName=@sourcegraph/amp
+ARG AMP_VERSION=0.0.1777248626-ga45149
+RUN set -eux; \
+    npm install -g @sourcegraph/amp@${AMP_VERSION}; \
+    amp --version
+
+# renovate: datasource=npm depName=cline
+ARG CLINE_VERSION=2.17.0
+RUN set -eux; \
+    npm install -g cline@${CLINE_VERSION}; \
+    cline --version
+
 USER hermes


### PR DESCRIPTION
Adds three npm AI coding tools to the Hermes test Dockerfile:

- **@qwen-code/qwen-code** v0.15.3
- **@sourcegraph/amp** v0.0.1777248626-ga45149  
- **cline** v2.17.0

Each includes Renovate tags (`datasource=npm`) for automatic version bumping, following the existing pattern already used for opencode-ai.