### PR TITLE
Add hledger and just to hermes-test image

### DIFF
--- a/dockerfiles/hermes-test.Dockerfile
+++ b/dockerfiles/hermes-test.Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
         findutils \
         coreutils \
         lsb-release \
+        hledger \
+        just \
     && rm -rf /var/lib/apt/lists/*
 
 # Download helper: retry + GitHub token auth + build cache
@@ -363,7 +365,9 @@ RUN set -eux; \
     btm --version; \
     gh --version; \
     gogcli --version; \
-    himalaya --version
+    himalaya --version; \
+    just --version; \
+    hledger --version || true
 
 # renovate: datasource=npm depName=opencode-ai
 ARG OPENCODE_VERSION=1.14.19


### PR DESCRIPTION
Install `hledger` and `just` from Debian trixie repos (both available for amd64 and arm64).

- **hledger** — double-entry accounting CLI, needed for personal finance dashboard pipeline (journal parsing via `hledger print --output-format json`)
- **just** — command runner, used as the task runner in the personal finance repo justfile

Both added to the `apt-get install` block and verified in the version check step.