### PR TITLE
Drop arm64 from hermes-test build

### DIFF
--- a/.github/workflows/hermes-test.yml
+++ b/.github/workflows/hermes-test.yml
@@ -33,9 +33,6 @@ jobs:
           repository: zarguell/auto_container_builds
           path: config-repo
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -50,7 +47,7 @@ jobs:
         with:
           context: ./config-repo
           file: ./config-repo/dockerfiles/hermes-test.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/hermes:test
           secrets: |


### PR DESCRIPTION
QEMU-emulated arm64 builds are slow and flaky (npm ETIMEDOUT). Not currently used. Removes QEMU setup step and switches to amd64-only.