### PR TITLE
fix: resolve build failures across 4 Dockerfiles

### DIFF
--- a/.github/workflows/documenso.yml
+++ b/.github/workflows/documenso.yml
@@ -28,10 +28,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push (MAIN)
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/documenso:latest
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          max_attempts=3
+          attempt=1
+          until docker buildx build \
+            --file docker/Dockerfile \
+            --platform linux/amd64,linux/arm64 \
+            --tag "${DOCKERHUB_USERNAME}/documenso:latest" \
+            --push .; do
+            if [ $attempt -ge $max_attempts ]; then
+              echo "All $max_attempts attempts failed"
+              exit 1
+            fi
+            echo "Build attempt $attempt failed (transient network?), retrying in 30s..."
+            sleep 30
+            attempt=$((attempt + 1))
+          done

--- a/dockerfiles/adexplorersnapshot-bloodhound.Dockerfile
+++ b/dockerfiles/adexplorersnapshot-bloodhound.Dockerfile
@@ -47,14 +47,14 @@ FROM python:3.14-slim-bookworm
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libstdc++6 \
-    libffi7 \
-    libssl1.1 \
+    libffi8 \
+    libssl3 \
     zlib1g \
     libjpeg62-turbo \
     libfreetype6 \
     liblcms2-2 \
     libopenjp2-7 \
-    libtiff5 \
+    libtiff6 \
     tk8.6 \
     tcl8.6 \
     libharfbuzz0b \

--- a/dockerfiles/pezor.Dockerfile
+++ b/dockerfiles/pezor.Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
         wget git clang g++ cmake autotools-dev build-essential \
         mingw-w64 unzip libcapstone-dev libssl-dev cowsay mono-devel \
         python3-pip golang wine64-tools && \
-    pip3 install --no-warn-script-location xortool && \
+    pip3 install --break-system-packages --no-warn-script-location xortool && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Clone repo,remove 'sudo' commands from the installation script and run the installation script for PEzor

--- a/dockerfiles/shredhound.Dockerfile
+++ b/dockerfiles/shredhound.Dockerfile
@@ -8,7 +8,7 @@ RUN git clone https://github.com/ustayready/shredhound.git .
 # Create virtual environment and install dependencies
 RUN python -m venv venv
 ENV PATH="/app/venv/bin:$PATH"
-RUN pip install -r requirements.txt
+# No requirements.txt needed — shred.py is pure stdlib with no external deps
 
 FROM cgr.dev/chainguard/python:latest
 

--- a/dockerfiles/shredhound.Dockerfile
+++ b/dockerfiles/shredhound.Dockerfile
@@ -3,20 +3,14 @@ FROM cgr.dev/chainguard/python:latest-dev AS builder
 WORKDIR /app
 
 # Clone the ShredHound repository
+# shred.py is pure stdlib — no external dependencies needed
 RUN git clone https://github.com/ustayready/shredhound.git .
-
-# Create virtual environment and install dependencies
-RUN python -m venv venv
-ENV PATH="/app/venv/bin:$PATH"
-# No requirements.txt needed — shred.py is pure stdlib with no external deps
 
 FROM cgr.dev/chainguard/python:latest
 
 WORKDIR /app
 
-# Copy application and virtual environment from builder
+# Copy the application from the builder stage
 COPY --from=builder /app /app
-
-ENV PATH="/app/venv/bin:$PATH"
 
 ENTRYPOINT ["python", "shred.py"]


### PR DESCRIPTION
## Summary

Fixes all 4 currently failing workflow builds.

### Changes

**1. `adexplorersnapshot-bloodhound.Dockerfile`** — Fix outdated Debian package names
- `python:3.14-slim-bookworm` is Debian 12 Bookworm, but the runtime stage listed packages from Debian 11 Bullseye
- `libffi7` → `libffi8`, `libssl1.1` → `libssl3`, `libtiff5` → `libtiff6`

**2. `pezor.Dockerfile`** — Fix PEP 668 externally-managed-environment error
- Debian 13 Trixie enforces PEP 668 — pip refuses system-wide installs outside a venv
- Added `--break-system-packages` to `pip3 install xortool`

**3. `shredhound.Dockerfile`** — Fix missing `requirements.txt`
- The upstream repo has never had a `requirements.txt` — it's a single-file pure-stdlib script with 0 external deps
- Removed the `pip install -r requirements.txt` line

**4. `documenso.yml`** — Fix transient npm registry timeout
- Replaced `docker/build-push-action` with shell-based `docker buildx build` that retries up to 3x with 30s backoff
- The upstream Dockerfile uses `npm ci` which can ETIMEOUT due to runner network flakiness