### PR TITLE
fix(pezor): add PIP_REQUIRE_VIRTUALENV=false for PEzor install.sh

### DIFF
--- a/dockerfiles/pezor.Dockerfile
+++ b/dockerfiles/pezor.Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Set environment variables to avoid interactive prompts and enable Go modules
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
+    PIP_REQUIRE_VIRTUALENV=false \
     PATH="/root/go/bin:/app/PEzor:/app/PEzor/deps/donut:/app/PEzor/deps/wclang/_prefix_PEzor_/bin:/usr/local/go/bin:${PATH}" \
     GO111MODULE=on
 


### PR DESCRIPTION
The upstream PEzor install.sh runs pip3 install without --break-system-packages,
which fails on Debian 13.5-slim (PEP 668 enforcement). Setting
PIP_REQUIRE_VIRTUALENV=false globally disables this check for all
pip calls in the build, including the install.sh subprocess.
